### PR TITLE
Fixed wrong configuration example in comment.

### DIFF
--- a/lib/logstash/outputs/webhdfs.rb
+++ b/lib/logstash/outputs/webhdfs.rb
@@ -32,7 +32,7 @@ require "stud/buffer"
 # }
 # output {
 #   webhdfs {
-#     server => "127.0.0.1:50070"         # (required)
+#     host => "127.0.0.1"                 # (required)
 #     path => "/user/logstash/dt=%{+YYYY-MM-dd}/logstash-%{+HH}.log"  # (required)
 #     user => "hue"                       # (required)
 #   }


### PR DESCRIPTION
Configuration option server was splitted into two separate options, host and port in https://github.com/logstash-plugins/logstash-output-webhdfs/commit/8e86cf0a351bfa716e216a75bfb6aaa0180cefff
