### PR TITLE
Fixed wrong configuration example in comment.

### DIFF
--- a/lib/logstash/outputs/webhdfs.rb
+++ b/lib/logstash/outputs/webhdfs.rb
@@ -34,7 +34,7 @@ require "logstash/outputs/webhdfs_helper"
 # output {
 #   webhdfs {
 #     host => "127.0.0.1"                 # (required)
-#     port => 50070			  # (optional, default: 50070)
+#     port => 50070                       # (optional, default: 50070)
 #     path => "/user/logstash/dt=%{+YYYY-MM-dd}/logstash-%{+HH}.log"  # (required)
 #     user => "hue"                       # (required)
 #   }

--- a/lib/logstash/outputs/webhdfs.rb
+++ b/lib/logstash/outputs/webhdfs.rb
@@ -33,7 +33,8 @@ require "logstash/outputs/webhdfs_helper"
 # }
 # output {
 #   webhdfs {
-#     server => "127.0.0.1:50070"         # (required)
+#     host => "127.0.0.1"                 # (required)
+#     port => 50070			  # (optional, default: 50070)
 #     path => "/user/logstash/dt=%{+YYYY-MM-dd}/logstash-%{+HH}.log"  # (required)
 #     user => "hue"                       # (required)
 #   }


### PR DESCRIPTION
Configuration option server was splitted into two separate options, host and port in https://github.com/logstash-plugins/logstash-output-webhdfs/commit/8e86cf0a351bfa716e216a75bfb6aaa0180cefff
