### PR TITLE
Added support for failover namenodes as requested in issue https://gi…

### DIFF
--- a/lib/logstash/outputs/webhdfs_helper.rb
+++ b/lib/logstash/outputs/webhdfs_helper.rb
@@ -31,7 +31,16 @@ module LogStash
         client.retry_times = @retry_times if @retry_times
         client
       end
-
+      # Test client connection.
+      #@param client [WebHDFS] webhdfs client object.
+      def test_client(client)
+        begin
+          client.list('/')
+        rescue => e
+          @logger.error("Webhdfs check request failed. (namenode: #{client.host}:#{client.port}, Exception: #{e.message})")
+          raise
+        end
+      end
 
       # Compress data using the gzip methods.
       # @param data [String] stream of data to be compressed


### PR DESCRIPTION
…thub.com/logstash-plugins/logstash-output-webhdfs/issues/17.

For configuring failover host, two new config parameters were introduced:
standby_host and standby_port.
As to not breaking exiting configurations and to avoid premature optimization the original host and port configuration parameters were not replaced by a dict of host:port combinations to allow for more than two failover hosts. If in future this will be supported by webhdfs we might need to change this.
