### PR TITLE
Force encoding the gemspec in UTF-8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,6 @@ language: ruby
 cache: bundler
 rvm:
   - jruby-1.7.25
+jdk: oraclejdk8
 script:
   - bundle exec rspec spec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# 3.0.1
+  - Force encoding the gemspec of this plugin into utf-8 to make sure updating all the plugin works see https://github.com/elastic/logstash/issues/5468
 # 3.0.0
   - Use new Event API defined in Logstash 5.x (backwards incompatible change)
 # 2.0.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 3.0.1
   - Force encoding the gemspec of this plugin into utf-8 to make sure updating all the plugin works see https://github.com/elastic/logstash/issues/5468
+  - Use oracle JDK8 for travis build
 # 3.0.0
   - Use new Event API defined in Logstash 5.x (backwards incompatible change)
 # 2.0.4

--- a/logstash-output-webhdfs.gemspec
+++ b/logstash-output-webhdfs.gemspec
@@ -1,8 +1,8 @@
-# encoding: utf-8
+﻿# encoding: utf-8
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-webhdfs'
-  s.version         = '3.0.0'
+  s.version         = '3.0.1'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Plugin to write events to hdfs via webhdfs."
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
The gemspec was using UTf-8 characters but the file content wasn't
explicitely set to utf-8.
