### PR TITLE
Add support for SSL and Basic HTTP authentication

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -53,6 +53,9 @@ output {
     port => 50070                       # (optional, default: 50070)
     path => "/user/logstash/dt=%{+YYYY-MM-dd}/logstash-%{+HH}.log"  # (required)
     user => "hue"                       # (required)
+    basicauth_user => "htuser"          # (optional, default: no basic HTTP auth)
+    basicauth_password => "123456"      # (optional)
+    use_ssl => true                     # (optional, default: false)
   }
 }
 ----------------------------------
@@ -88,6 +91,10 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-use_kerberos_auth>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-use_ssl_auth>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-user>> |<<string,string>>|Yes
+| <<plugins-{type}s-{plugin}-basicauth_user>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-basicauth_password>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-use_ssl>> |<<boolean,boolean>>|No
+| <<plugins-{type}s-{plugin}-verify_ssl>> |<<boolean,boolean>>|No
 |=======================================================================
 
 Also see <<plugins-{type}s-{plugin}-common-options>> for a list of options supported by all

--- a/lib/logstash/outputs/webhdfs.rb
+++ b/lib/logstash/outputs/webhdfs.rb
@@ -67,6 +67,12 @@ class LogStash::Outputs::WebHdfs < LogStash::Outputs::Base
   # The Username for webhdfs.
   config :user, :validate => :string, :required => true
 
+  # The Username for Basic HTTP authentication
+  config :basicauth_user, :validate => :string, :default => nil
+
+  # The Password for Basic HTTP authentication
+  config :basicauth_password, :validate => :string, :default => nil
+
   # The path to the file to write to. Event fields can be used here,
   # as well as date fields in the joda time format, e.g.:
   # `/user/logstash/dt=%{+YYYY-MM-dd}/%{@source_host}-%{+HH}.log`
@@ -116,6 +122,12 @@ class LogStash::Outputs::WebHdfs < LogStash::Outputs::Base
 
   # Set kerberos keytab file. Note that the gssapi library needs to be available to use this.
   config :kerberos_keytab, :validate => :string
+
+  # Use SSL
+  config :use_ssl, :validate => :boolean, :default => false
+
+  # Verify SSL
+  config :verify_ssl, :validate => :boolean, :default => true
 
   # Set ssl authentication. Note that the openssl library needs to be available to use this.
   config :use_ssl_auth, :validate => :boolean, :default => false


### PR DESCRIPTION
This patch adds support for WebFS and HTTPFS servers that live behind some Basic HTTP Authentication, and/or SSL-without-SSL-authentication.  One possible use case is when the WebFS node is behind a reverse proxy.