### PR TITLE
Error handling and retry behaviour improved

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -76,6 +76,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-port>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-read_timeout>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-retry_interval>> |<<number,number>>|No
+| <<plugins-{type}s-{plugin}-retry_max_interval>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-retry_known_errors>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-retry_times>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-single_file_per_thread>> |<<boolean,boolean>>|No
@@ -178,7 +179,15 @@ The WebHdfs read timeout, default 30s.
   * Value type is <<number,number>>
   * Default value is `0.5`
 
-How long should we wait between retries.
+Initial interval (in seconds) waited between consecutive retries. Actual interval increases with each retry and is proportional to the number of executed attempts, up to limit given in `retry_max_interval`.
+
+[id="plugins-{type}s-{plugin}-retry_max_interval"]
+===== `retry_max_interval` 
+
+  * Value type is <<number,number>>
+  * Default value is `-1`
+
+Max interval (in seconds) waited between consecutive retries. Set to `-1` for unlimited retry interval.
 
 [id="plugins-{type}s-{plugin}-retry_known_errors"]
 ===== `retry_known_errors` 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -179,7 +179,7 @@ The WebHdfs read timeout, default 30s.
   * Value type is <<number,number>>
   * Default value is `0.5`
 
-Initial interval (in seconds) waited between consecutive retries. Actual interval increases with each retry and is proportional to the number of executed attempts, up to limit given in `retry_max_interval`.
+Initial interval (in seconds) waited between consecutive retries. Actual interval increases with each retry and is proportional to the number of executed attempts, up to the limit given in `retry_max_interval`.
 
 [id="plugins-{type}s-{plugin}-retry_max_interval"]
 ===== `retry_max_interval` 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -194,7 +194,7 @@ Retry some known webhdfs errors. These may be caused by race conditions when app
   * Value type is <<number,number>>
   * Default value is `5`
 
-How many times should we retry. If retry_times is exceeded, an error will be logged and the event will be discarded.
+How many times should we retry. If retry_times is exceeded, an error will be logged and the event will be discarded. Set to `-1` for infinite retries.
 
 [id="plugins-{type}s-{plugin}-single_file_per_thread"]
 ===== `single_file_per_thread` 

--- a/lib/logstash/outputs/webhdfs.rb
+++ b/lib/logstash/outputs/webhdfs.rb
@@ -95,10 +95,15 @@ class LogStash::Outputs::WebHdfs < LogStash::Outputs::Base
   # Retry some known webhdfs errors. These may be caused by race conditions when appending to same file, etc.
   config :retry_known_errors, :validate => :boolean, :default => true
 
-  # How long should we wait between retries.
+  # Initial interval (in seconds) waited between consecutive retries. Actual interval increases with each retry
+  # and is proportional to the number of executed attempts, up to limit given in `retry_max_interval`.
   config :retry_interval, :validate => :number, :default => 0.5
 
-  # How many times should we retry. If retry_times is exceeded, an error will be logged and the event will be discarded.
+  # Max interval (in seconds) waited between consecutive retries. Set to `-1` for unlimited retry interval.
+  config :retry_max_interval, :validate => :number, :default => -1
+
+  # How many times should we retry. If retry_times is exceeded, an error will be logged and the event will be discarded. 
+  # Set to `-1` for infinite retries.
   config :retry_times, :validate => :number, :default => 5
 
   # Compress output. One of ['none', 'snappy', 'gzip']
@@ -230,14 +235,18 @@ class LogStash::Outputs::WebHdfs < LogStash::Outputs::Base
     # Handle other write errors and retry to write max. @retry_times.
     rescue => e
       if write_tries < @retry_times || @retry_times == -1
+        write_tries += 1
         # Handle StandbyException and do failover. Still we want to exit if write_tries >= @retry_times.
         if @standby_client && (e.message.match(/Failed to connect to host #{@client.host}:#{@client.port}/) || e.message.match(/StandbyException/))
           do_failover
         else
           @logger.warn("webhdfs write caused an exception: #{e.message}. Maybe you should increase retry_interval or reduce number of workers. Retrying...")
-          sleep(@retry_interval * write_tries)
+          sleep_interval = @retry_interval * write_tries
+          if @retry_max_interval != -1 && sleep_interval > @retry_max_interval
+            sleep_interval = @retry_max_interval
+          end
+          sleep(sleep_interval)
         end
-        write_tries += 1
         retry
       else
         # Issue error after max retries.

--- a/lib/logstash/outputs/webhdfs.rb
+++ b/lib/logstash/outputs/webhdfs.rb
@@ -96,7 +96,7 @@ class LogStash::Outputs::WebHdfs < LogStash::Outputs::Base
   config :retry_known_errors, :validate => :boolean, :default => true
 
   # Initial interval (in seconds) waited between consecutive retries. Actual interval increases with each retry
-  # and is proportional to the number of executed attempts, up to limit given in `retry_max_interval`.
+  # and is proportional to the number of executed attempts, up to the limit given in `retry_max_interval`.
   config :retry_interval, :validate => :number, :default => 0.5
 
   # Max interval (in seconds) waited between consecutive retries. Set to `-1` for unlimited retry interval.
@@ -218,8 +218,8 @@ class LogStash::Outputs::WebHdfs < LogStash::Outputs::Base
   end
 
   def write_data(path, data)
-    # Retry max_retry times. This can solve problems like leases being hold by another process. Sadly this is no
-    # KNOWN_ERROR in rubys webhdfs client.
+    # Retry max_retry times. This can solve problems like leases being held by another process. Sadly this is no
+    # KNOWN_ERROR in ruby's webhdfs client.
     write_tries = 0
     begin
       # Try to append to already existing file, which will work most of the times.
@@ -236,7 +236,7 @@ class LogStash::Outputs::WebHdfs < LogStash::Outputs::Base
     rescue => e
       if write_tries < @retry_times || @retry_times == -1
         write_tries += 1
-        # Handle StandbyException and do failover. Still we want to exit if write_tries >= @retry_times.
+        # Handle StandbyException and do failover.
         if @standby_client && (e.message.match(/Failed to connect to host #{@client.host}:#{@client.port}/) || e.message.match(/StandbyException/))
           do_failover
         else

--- a/lib/logstash/outputs/webhdfs.rb
+++ b/lib/logstash/outputs/webhdfs.rb
@@ -231,7 +231,7 @@ class LogStash::Outputs::WebHdfs < LogStash::Outputs::Base
     rescue => e
       if write_tries < @retry_times || @retry_times == -1
         # Handle StandbyException and do failover. Still we want to exit if write_tries >= @retry_times.
-        if @standby_client && (e.message.match(/Failed to connect to host/) || e.message.match(/StandbyException/))
+        if @standby_client && (e.message.match(/Failed to connect to host #{@client.host}:#{@client.port}/) || e.message.match(/StandbyException/))
           do_failover
         else
           @logger.warn("webhdfs write caused an exception: #{e.message}. Maybe you should increase retry_interval or reduce number of workers. Retrying...")

--- a/lib/logstash/outputs/webhdfs.rb
+++ b/lib/logstash/outputs/webhdfs.rb
@@ -235,7 +235,7 @@ class LogStash::Outputs::WebHdfs < LogStash::Outputs::Base
         write_tries += 1
         retry
       end
-      if write_tries < @retry_times
+      if write_tries < @retry_times || @retry_times == -1
         @logger.warn("webhdfs write caused an exception: #{e.message}. Maybe you should increase retry_interval or reduce number of workers. Retrying...")
         sleep(@retry_interval * write_tries)
         write_tries += 1

--- a/lib/logstash/outputs/webhdfs.rb
+++ b/lib/logstash/outputs/webhdfs.rb
@@ -209,7 +209,7 @@ class LogStash::Outputs::WebHdfs < LogStash::Outputs::Base
         path += ".snappy"
         if @snappy_format == "file"
           output = compress_snappy_file(output)
-        elsif
+        else
           output = compress_snappy_stream(output)
         end
       end
@@ -230,7 +230,7 @@ class LogStash::Outputs::WebHdfs < LogStash::Outputs::Base
         # Add snappy header if format is "file".
         if @compression == "snappy" and @snappy_format == "file"
           @client.create(path, get_snappy_header! + data)
-        elsif
+        else
           @client.create(path, data)
         end
       end
@@ -243,7 +243,7 @@ class LogStash::Outputs::WebHdfs < LogStash::Outputs::Base
         if @standby_client && (e.message.match(/Failed to connect to host #{@client.host}:#{@client.port}/) || e.message.match(/StandbyException/))
           do_failover
         else
-          @logger.warn("webhdfs write caused an exception: #{e.message}. Maybe you should increase retry_interval or reduce number of workers. Retrying...")
+          @logger.warn("webhdfs write caused an exception: #{e.message}. Maybe you should increase retry_interval or reduce the number of workers. Retrying...")
           sleep_interval = @retry_interval * write_tries
           if @retry_max_interval != -1 && sleep_interval > @retry_max_interval
             sleep_interval = @retry_max_interval

--- a/spec/outputs/webhdfs_spec.rb
+++ b/spec/outputs/webhdfs_spec.rb
@@ -54,6 +54,10 @@ describe 'outputs/webhdfs' do
         expect(subject.retry_interval).to eq(0.5)
       end
 
+      it 'should have default retry_max_interval' do
+        expect(subject.retry_max_interval).to eq(-1)
+      end
+
       it 'should have default retry_times' do
         expect(subject.retry_times).to eq(5)
       end


### PR DESCRIPTION
Several changes in error handling:
* **Support for infinite retries added** - better fits logstash philosophy of not dropping events in case of errors in order to provide data integrity,
* **Properly use 'retry_times' in case of failovers** - previously 'retry_times' parameter was ignored in case of failovers thus leading to infinite retries,
* **Reducing unnecessary failovers due to conn errors** - solves #36 
* **Optional limit for retry interval added** - useful in case of infinite retries as retry interval increases with each attempt potentially resulting in extremely high values,
* **Docs improved** - better description of retry behaviour and retry_interval increments,
* **Properly handle errors during file creation** - previously errors encountered during file creation were not handled at all; now they are treated just like any other write error