### PR TITLE
Remove inefficient Regexp scan in compress_snappy_stream

### DIFF
--- a/lib/logstash/outputs/webhdfs_helper.rb
+++ b/lib/logstash/outputs/webhdfs_helper.rb
@@ -85,8 +85,10 @@ module LogStash
         data= data.encode(Encoding::ASCII_8BIT, "binary", :undef => :replace)
         buffer = StringIO.new
         buffer.set_encoding(Encoding::ASCII_8BIT)
-        chunks = data.scan(/.{1,#{@snappy_bufsize}}/m)
-        chunks.each do |chunk|
+        idx = 0
+        while idx < data.length
+          chunk = data[idx, @snappy_bufsize]
+          idx += @snappy_bufsize
           compressed = Snappy.deflate(chunk)
           buffer << [chunk.size, compressed.size, compressed].pack("NNa*")
         end


### PR DESCRIPTION
Contrary to our expectation, we observed that logstash process consumes more CPU time when using Snappy compression than when using gzip.

Profiling shows that the Regexp scans for splitting the input data into chunks were using a large portion of the CPU time.

![image](https://user-images.githubusercontent.com/700826/143810356-9c20c1f4-82c4-4bca-9e87-fce22a05046c.png)

We can change it to a simple substring loop and remove the unnecessary overhead.
